### PR TITLE
Fixed Objectives text.

### DIFF
--- a/Updates/1753_Q7_Objectives.sql
+++ b/Updates/1753_Q7_Objectives.sql
@@ -1,0 +1,8 @@
+-- Required count is 6, but the Objectives says 8. Changed text from 8 to 6.
+-- https://www.wowhead.com/quest=7/deprecated-kobold-camp-cleanup
+UPDATE
+	`quest_template`
+SET
+	`Objectives` = 'Kill 6 Kobold Vermin, then return to Marshal McBride.'
+WHERE
+	`entry` = 7;


### PR DESCRIPTION
Required count is 6, but the Objectives says 8. Changed text from 8 to 6.
https://www.wowhead.com/quest=7/deprecated-kobold-camp-cleanup