### PR TITLE
2854 Fix chained peasant for DK quest

### DIFF
--- a/Updates/2854_chained_peasant.sql
+++ b/Updates/2854_chained_peasant.sql
@@ -1,0 +1,2 @@
+--- Chained Peasant 54612 54613 fixes https://github.com/cmangos/issues/issues/2116
+UPDATE spell_template SET AttributesEx2 = AttributesEx2|4 WHERE id IN (54612, 54613);


### PR DESCRIPTION
Fixes https://github.com/cmangos/issues/issues/2116 so Death Knight quest "The Endless Hunger" works properly by updating spell_template for ids 54612 54613