### PR TITLE
Increased quest item count from 1 to 4 for quests "Disrupt Their Reinforcements"

### DIFF
--- a/Updates/3164_fix_disrupt_their_reinforcements.sql
+++ b/Updates/3164_fix_disrupt_their_reinforcements.sql
@@ -1,0 +1,2 @@
+-- Players need 4 "Demonic Rune Stone" to disrupt portals in quest "Disrupt Their Reinforcements"
+UPDATE quest_template SET ReqSourceCount3 = 4 WHERE entry IN (10144, 10208);

--- a/Updates/3164_fix_disrupt_their_reinforcements.sql
+++ b/Updates/3164_fix_disrupt_their_reinforcements.sql
@@ -1,2 +1,2 @@
--- Players need 4 "Demonic Rune Stone" to disrupt portals in quest "Disrupt Their Reinforcements"
-UPDATE quest_template SET ReqSourceCount3 = 4 WHERE entry IN (10144, 10208);
+-- Players need 4 "Demonic Rune Stone" to disrupt each of the two portals in quest "Disrupt Their Reinforcements"
+UPDATE quest_template SET ReqSourceCount3 = 8 WHERE entry IN (10144, 10208);


### PR DESCRIPTION
You need 4 "Demonic Rune Stone" to destroy one portal, but currently enemies won't drop any more after you get the first one. There are two portals that need 4 each, but I was unable to find a source that showed just how many you can carry (whether you can carry 8 at a time, for example). I set it to 4 to decrease the probability of remaining items after finishing quest.

This patch might be relevant for TBC database as well (haven't checked).

You might want to update the number for the SQL file as well, forgot to pull latest changes before creating new file, but I guess it hardly matters, will probably be outdated when it'll be merged.