### PR TITLE
[3286] c.6776 'Magrin Rivermane'

### DIFF
--- a/Updates/3286_c.6776.sql
+++ b/Updates/3286_c.6776.sql
@@ -1,0 +1,2 @@
+-- Magrin Rivermane 6776
+UPDATE creature_template SET NpcFlags = 2 WHERE entry = 6776;


### PR DESCRIPTION
Magrin Rivermane is not a vendor in wotlk.