### PR TITLE
Remove duplicate Shadow Resistance racial spell from Draenei

### DIFF
--- a/Updates/3695_remove_draenei_racial_duplicates.sql
+++ b/Updates/3695_remove_draenei_racial_duplicates.sql
@@ -1,0 +1,1 @@
+DELETE FROM `playercreateinfo_spell` WHERE `race`=11 AND `Spell` IN (59221, 59539);


### PR DESCRIPTION
In WotLK, the Draenei racial Shadow Resistance was changed from its TBC version. Now every Draenei class has their own separate Shadow Resistance racial, each with a different spell id. [Here's the list](https://wotlkdb.com/?spell=59221#see-also).
The current data in playercreateinfo_spell uses the Warrior's version for every class other than Death Knight - so if you create a Draenei Paladin, it will have two Shadow Resistance versions in the spellbook.
This spell is learned from the skill [Racial - Draenei](https://www.wowhead.com/skill=760), so it can be safely removed from playercreateinfo_spell.