### PR TITLE
Improve behavior of NPC Balos Jacken involved in quest The Deserters (1286)

### DIFF
--- a/Updates/3697_balos_jacken.sql
+++ b/Updates/3697_balos_jacken.sql
@@ -1,0 +1,4 @@
+DELETE FROM `dbscripts_on_relay` WHERE `id` IN (10209, 10210);
+INSERT INTO `dbscripts_on_relay` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(10209, 0, 0, 29, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Balos Jacken - Remove NpcFlag Questgiver"),
+(10210, 0, 0, 29, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Balos Jacken - Add NpcFlag Questgiver");


### PR DESCRIPTION
- He should be immortal, even if attacked by Horde players. This is common behavior across NPCs that become friendly at low health.
- His text was wrong, had wrong language and was missing talk emote.
- He returns aggressive after 3 minutes, not 2.
- His faction when becoming friendly was wrong.
- The NPC starts without the questgiver flag. He obtains it (as well as immune to pc and npc flags) after he reaches home, not while evading.

All of this was verified via sniffs.

This is valid for TBC and I believe for Vanilla too (after changing the field for action 17), as this quest was not among those added in TBC.

To test:
.go creature id 5089
Target Balos Jacken
.damage 999999