### PR TITLE
Send Argent Tournament mail to characters that reach level 77

### DIFF
--- a/Updates/3702_argent_tournament_mail.sql
+++ b/Updates/3702_argent_tournament_mail.sql
@@ -1,0 +1,4 @@
+DELETE FROM `mail_level_reward` WHERE `level`=77 AND `mailTemplateId`=265;
+INSERT INTO `mail_level_reward` (`level`, `raceMask`, `mailTemplateId`, `senderEntry`) VALUES
+(77, 1791, 265, 33817);
+


### PR DESCRIPTION
When a player reaches level 77, a mail from [Justicar Mariel Trueheart](https://www.wowhead.com/npc=33817/justicar-mariel-trueheart) is received (because players can take the flight path from a Dalaran NPC and start the Tournament quests at that level).

[Source of the claim](https://www.wowhead.com/npc=33817/justicar-mariel-trueheart#comments:id=892355).

To test:
- Create a new character.
- .tele dalaran (or wherever there's a mailbox)
- .levelup 76
- Check the mailbox.