### PR TITLE
Fix mangos_string entry for .debug areatriggers command

### DIFF
--- a/Updates/3729_mangos_strings.sql
+++ b/Updates/3729_mangos_strings.sql
@@ -12,9 +12,9 @@ DELETE FROM `command` WHERE `name`='list areatriggers';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('list areatriggers', 3, 'Syntax: .list areatriggers\n\nShow areatriggers within the same map (if inside an instanceable map) or area (if inside a continent) as the user.');
 
-DELETE FROM `mangos_string` WHERE `entry`=555;
+DELETE FROM `mangos_string` WHERE `entry`=573;
 INSERT INTO `mangos_string` (`entry`, `content_default`) VALUES
-(555, 'Showing all areatriggers in %s %s:');
+(573, 'Showing all areatriggers in %s %s:');
 
 DELETE FROM `command` WHERE `name`='go warp';
 INSERT INTO `command` (`name`, `security`, `help`) VALUES


### PR DESCRIPTION
Was renumbered in https://github.com/cmangos/mangos-wotlk/commit/2cd2793ed5202cad952ab8915506776288637a1c but not in https://github.com/Nytanath/wotlk-db/commit/fe631a8aaf3d6f42162a7c4830df3017d7bcbdd6.