### PR TITLE
CI: Update GitHub runners to latest version and replace some deprecated functions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -31,12 +31,12 @@ jobs:
           echo "DB_FOLDER="${{github.workspace}}/${expansion}-db >> $GITHUB_ENV
 
       - name: Checkout DB
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{env.DB_FOLDER}}
 
       - name: Checkout CORE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{env.CORE_REPO}}
           path: ${{env.CORE_FOLDER}}
@@ -52,7 +52,7 @@ jobs:
 
   notify-failure:
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     if: failure()

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,16 +38,17 @@ jobs:
           echo "CHAR_DB_NAME=${expansion}characters" >> $env:GITHUB_ENV
           echo "REALM_DB_NAME=${expansion}realmd" >> $env:GITHUB_ENV
           echo "LOGS_DB_NAME=${expansion}logs" >> $env:GITHUB_ENV
+          echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
           md -Force "${{env.CACHED_FOLDER}}"
           md -Force "${{env.WORK_FOLDER}}"
 
       - name: Checkout DB
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{env.DB_FOLDER}}
 
       - name: Checkout CORE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{env.CORE_REPO}}
           path: ${{env.CORE_FOLDER}}
@@ -198,7 +199,7 @@ jobs:
           choco install gawk
 
       - name: Checkout mysql2sqlite
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: dumblob/mysql2sqlite
           path: ${{env.CORE_FOLDER}}/mysql2sqlite
@@ -219,22 +220,18 @@ jobs:
           7z a -tzip "${{github.workspace}}\releases\${{env.EXPANSION_NAME}}-all-db.zip" "${{env.FINAL_SQL_FOLDER}}\*.sql"
           7z a -tzip "${{github.workspace}}\releases\${{env.EXPANSION_NAME}}-sqlite-db.zip" "${{env.FINAL_SQL_FOLDER}}\*.sqlite"
 
-      - name: Get Current Date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
       - name: Upload Snapshot
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.PUSH_RELEASE_TOKEN }}"
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: false
-          title: "Development Build(${{ steps.date.outputs.date }})"
+          title: "Development Build(${{env.BUILD_DATE}})"
           files: releases
 
   notify-success:
     name: Send Notification to Discord on Success
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
 
@@ -269,7 +266,7 @@ jobs:
 
   notify-failure:
     name: Send Notification to Discord on Failure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: none
     if: failure()


### PR DESCRIPTION
The automatic release action is throwing warnings as well so a replacement will need to be looked at eventually but this will restore the nightly builds.