### PR TITLE
MySQL: Download correct pre-built server binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  MYSQL_BIN_NAME: "mysql-8.0.41-winx64"
+  MYSQL_BIN_NAME: "mysql-8.0.46-winx64"
   MYSQL_BASE_PREBUILD_ADR: "https://cdn.mysql.com/Downloads/MySQL-8.0/"
   MYSQL_BIN_EXT: ".zip"
   MYSQL_FINAL_SERVER_FOLDER: "mysql-server"


### PR DESCRIPTION
This PR fixes the MySQL server version to one that still exists, so automated builds can work again.