### PR TITLE
ICC: restore Crimson Hall data and rewards

### DIFF
--- a/Updates/5866_icc_lower_spire.sql
+++ b/Updates/5866_icc_lower_spire.sql
@@ -1,0 +1,60 @@
+-- Icecrown Citadel lower-spire world data.
+-- Companion update for the lower-spire ScriptDev2 implementation.
+
+START TRANSACTION;
+
+-- Nerub'ar Broodkeeper: restore Dark Mending.
+UPDATE `creature_ai_scripts`
+SET `action1_param1` = 71020,
+    `comment` = 'Nerub''ar Broodkeeper - Cast Dark Mending on Friendly Missing HP'
+WHERE `id` = 3672503
+  AND `creature_id` = 36725;
+
+-- The instance script owns the two-kill Light's Hammer prologue.
+DELETE FROM `creature_ai_scripts`
+WHERE `id` = 3701104
+  AND `creature_id` = 37011;
+
+-- This is the non-combat forward gate at Light's Hammer.
+UPDATE `gameobject_template`
+SET `data0` = 1,
+    `data2` = 0
+WHERE `entry` = 201583
+  AND `type` = 0;
+
+-- Zafod's client-known spell lacks the server-side create-item data.
+INSERT INTO `spell_template`
+    (`Id`, `Attributes`, `AttributesEx2`, `ProcChance`, `Effect1`,
+     `EffectImplicitTargetA1`, `EffectItemType1`, `SpellName`, `SchoolMask`)
+VALUES
+    (70055, 384, 4, 101, 24, 25, 49278, 'Create Rocket Pack', 1)
+ON DUPLICATE KEY UPDATE
+    `ProcChance` = VALUES(`ProcChance`),
+    `Effect1` = VALUES(`Effect1`),
+    `EffectImplicitTargetA1` = VALUES(`EffectImplicitTargetA1`),
+    `EffectItemType1` = VALUES(`EffectItemType1`);
+
+-- Restrict each cannon to players of its owning faction.
+INSERT IGNORE INTO `conditions`
+    (`condition_entry`,`type`,`value1`,`value2`,`value3`,`value4`,`flags`,`comments`)
+VALUES
+    (21,6,67,0,0,0,0,'Horde Player'),
+    (22,6,469,0,0,0,0,'Alliance Player');
+
+DELETE FROM `npc_spellclick_spells`
+WHERE `npc_entry` IN (36838,36839)
+  AND `spell_id` = 70510;
+
+INSERT INTO `npc_spellclick_spells`
+    (`npc_entry`,`spell_id`,`quest_start`,`quest_start_active`,`quest_end`,`cast_flags`,`condition_id`)
+VALUES
+    (36838,70510,0,0,0,1,22),
+    (36839,70510,0,0,0,1,21);
+
+-- Cannon heat is encounter-controlled; generic power regeneration races it.
+UPDATE `creature_template`
+SET `RegenerateStats` = `RegenerateStats` & ~4
+WHERE `Entry` IN (36838,36839);
+
+COMMIT;
+

--- a/Updates/5867_icc_lower_spire_rewards.sql
+++ b/Updates/5867_icc_lower_spire_rewards.sql
@@ -1,0 +1,201 @@
+-- Icecrown Citadel lower-spire reward caches.
+-- Fixes Gunship and Deathbringer Saurfang loot for 10N/25N/10H/25H.
+-- Also installs one correctly masked cache per faction/difficulty.
+-- Safe to rerun against the world database.
+
+START TRANSACTION;
+
+-- Reference IDs reserved for the ICC lower-spire reward pools.
+DELETE FROM `reference_loot_template`
+WHERE `entry` BETWEEN 65001 AND 65010;
+
+INSERT INTO `reference_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+-- Gunship 10 normal
+(65001,50340,0,1,1,1,0,'Muradin''s Spyglass'),
+(65001,50787,0,1,1,1,0,'Frost Giant''s Cleaver'),
+(65001,50788,0,1,1,1,0,'Bone Drake''s Enameled Boots'),
+(65001,50789,0,1,1,1,0,'Icecrown Rampart Bracers'),
+(65001,50790,0,1,1,1,0,'Abomination''s Bloody Ring'),
+(65001,50791,0,1,1,1,0,'Saronite Gargoyle Cloak'),
+(65001,50792,0,1,1,1,0,'Pauldrons of Lost Hope'),
+(65001,50793,0,1,1,1,0,'Midnight Sun'),
+(65001,50794,0,1,1,1,0,'Neverending Winter'),
+(65001,50795,0,1,1,1,0,'Cord of Dark Suffering'),
+(65001,50796,0,1,1,1,0,'Bracers of Pale Illumination'),
+(65001,50797,0,1,1,1,0,'Ice-Reinforced Vrykul Helm'),
+-- Gunship 25 normal
+(65002,49998,0,1,1,1,0,'Shadowvault Slayer''s Cloak'),
+(65002,49999,0,1,1,1,0,'Skeleton Lord''s Circle'),
+(65002,50000,0,1,1,1,0,'Scourge Hunter''s Vambraces'),
+(65002,50001,0,1,1,1,0,'Ikfirus'' Sack of Wonder'),
+(65002,50002,0,1,1,1,0,'Polar Bear Claw Bracers'),
+(65002,50003,0,1,1,1,0,'Boneguard Commander''s Pauldrons'),
+(65002,50005,0,1,1,1,0,'Amulet of the Silent Eulogy'),
+(65002,50006,0,1,1,1,0,'Corp''rethar Ceremonial Crown'),
+(65002,50008,0,1,1,1,0,'Ring of Rapid Ascent'),
+(65002,50009,0,1,1,1,0,'Boots of Unnatural Growth'),
+(65002,50010,0,1,1,1,0,'Waistband of Righteous Fury'),
+(65002,50011,0,1,1,1,0,'Gunship Captain''s Mittens'),
+(65002,50352,0,1,1,1,0,'Corpse Tongue Coin'),
+(65002,50359,0,1,1,1,0,'Althor''s Abacus'),
+(65002,50411,0,1,1,1,0,'Scourgeborne Waraxe'),
+-- Gunship 10 heroic
+(65003,50345,0,1,1,1,0,'Muradin''s Spyglass heroic'),
+(65003,51906,0,1,1,1,0,'Ice-Reinforced Vrykul Helm heroic'),
+(65003,51907,0,1,1,1,0,'Bracers of Pale Illumination heroic'),
+(65003,51908,0,1,1,1,0,'Cord of Dark Suffering heroic'),
+(65003,51909,0,1,1,1,0,'Neverending Winter heroic'),
+(65003,51910,0,1,1,1,0,'Midnight Sun heroic'),
+(65003,51911,0,1,1,1,0,'Pauldrons of Lost Hope heroic'),
+(65003,51912,0,1,1,1,0,'Saronite Gargoyle Cloak heroic'),
+(65003,51913,0,1,1,1,0,'Abomination''s Bloody Ring heroic'),
+(65003,51914,0,1,1,1,0,'Icecrown Rampart Bracers heroic'),
+(65003,51915,0,1,1,1,0,'Bone Drake''s Enameled Boots heroic'),
+(65003,51916,0,1,1,1,0,'Frost Giant''s Cleaver heroic'),
+-- Gunship 25 heroic
+(65004,50349,0,1,1,1,0,'Corpse Tongue Coin heroic'),
+(65004,50366,0,1,1,1,0,'Althor''s Abacus heroic'),
+(65004,50653,0,1,1,1,0,'Shadowvault Slayer''s Cloak heroic'),
+(65004,50654,0,1,1,1,0,'Scourgeborne Waraxe heroic'),
+(65004,50655,0,1,1,1,0,'Scourge Hunter''s Vambraces heroic'),
+(65004,50656,0,1,1,1,0,'Ikfirus'' Sack of Wonder heroic'),
+(65004,50657,0,1,1,1,0,'Skeleton Lord''s Circle heroic'),
+(65004,50658,0,1,1,1,0,'Amulet of the Silent Eulogy heroic'),
+(65004,50659,0,1,1,1,0,'Polar Bear Claw Bracers heroic'),
+(65004,50660,0,1,1,1,0,'Boneguard Commander''s Pauldrons heroic'),
+(65004,50661,0,1,1,1,0,'Corp''rethar Ceremonial Crown heroic'),
+(65004,50663,0,1,1,1,0,'Gunship Captain''s Mittens heroic'),
+(65004,50664,0,1,1,1,0,'Ring of Rapid Ascent heroic'),
+(65004,50665,0,1,1,1,0,'Boots of Unnatural Growth heroic'),
+(65004,50667,0,1,1,1,0,'Waistband of Righteous Fury heroic'),
+-- Saurfang 10 normal
+(65005,50798,0,1,1,1,0,'Ramaladni''s Blade of Culling'),
+(65005,50799,0,1,1,1,0,'Scourge Stranglers'),
+(65005,50800,0,1,1,1,0,'Hauberk of a Thousand Cuts'),
+(65005,50801,0,1,1,1,0,'Blade-Scored Carapace'),
+(65005,50802,0,1,1,1,0,'Gargoyle Spit Bracers'),
+(65005,50803,0,1,1,1,0,'Saurfang''s Cold-Forged Band'),
+(65005,50804,0,1,1,1,0,'Icecrown Spire Sandals'),
+(65005,50805,0,1,1,1,0,'Mag''hari Chieftain''s Staff'),
+(65005,50806,0,1,1,1,0,'Leggings of Unrelenting Blood'),
+(65005,50807,0,1,1,1,0,'Thaumaturge''s Crackling Cowl'),
+(65005,50808,0,1,1,1,0,'Deathforged Legplates'),
+(65005,50809,0,1,1,1,0,'Soulcleave Pendant'),
+-- Saurfang 10 heroic
+(65006,51894,0,1,1,1,0,'Soulcleave Pendant heroic'),
+(65006,51895,0,1,1,1,0,'Deathforged Legplates heroic'),
+(65006,51896,0,1,1,1,0,'Thaumaturge''s Crackling Cowl heroic'),
+(65006,51897,0,1,1,1,0,'Leggings of Unrelenting Blood heroic'),
+(65006,51898,0,1,1,1,0,'Mag''hari Chieftain''s Staff heroic'),
+(65006,51899,0,1,1,1,0,'Icecrown Spire Sandals heroic'),
+(65006,51900,0,1,1,1,0,'Saurfang''s Cold-Forged Band heroic'),
+(65006,51901,0,1,1,1,0,'Gargoyle Spit Bracers heroic'),
+(65006,51902,0,1,1,1,0,'Blade-Scored Carapace heroic'),
+(65006,51903,0,1,1,1,0,'Hauberk of a Thousand Cuts heroic'),
+(65006,51904,0,1,1,1,0,'Scourge Stranglers heroic'),
+(65006,51905,0,1,1,1,0,'Ramaladni''s Blade of Culling heroic'),
+-- Saurfang 25 normal
+(65007,50014,0,1,1,1,0,'Greatcloak of the Turned Champion'),
+(65007,50015,0,1,1,1,0,'Belt of the Blood Nova'),
+(65007,50333,0,1,1,1,0,'Toskk''s Maximized Wristguards'),
+(65007,50362,0,1,1,1,0,'Deathbringer''s Will'),
+(65007,50412,0,1,1,1,0,'Bloodvenom Blade'),
+-- Saurfang 25 heroic
+(65008,50363,0,1,1,1,0,'Deathbringer''s Will heroic'),
+(65008,50668,0,1,1,1,0,'Greatcloak of the Turned Champion heroic'),
+(65008,50670,0,1,1,1,0,'Toskk''s Maximized Wristguards heroic'),
+(65008,50671,0,1,1,1,0,'Belt of the Blood Nova heroic'),
+(65008,50672,0,1,1,1,0,'Bloodvenom Blade heroic'),
+-- Tier tokens
+(65009,52025,0,1,1,1,0,'Vanquisher''s Mark of Sanctification'),
+(65009,52026,0,1,1,1,0,'Protector''s Mark of Sanctification'),
+(65009,52027,0,1,1,1,0,'Conqueror''s Mark of Sanctification'),
+(65010,52028,0,1,1,1,0,'Vanquisher''s Mark of Sanctification heroic'),
+(65010,52029,0,1,1,1,0,'Protector''s Mark of Sanctification heroic'),
+(65010,52030,0,1,1,1,0,'Conqueror''s Mark of Sanctification heroic');
+
+REPLACE INTO `reference_loot_template_names` (`entry`,`name`) VALUES
+(65001,'ICC Gunship 10 Normal'),
+(65002,'ICC Gunship 25 Normal'),
+(65003,'ICC Gunship 10 Heroic'),
+(65004,'ICC Gunship 25 Heroic'),
+(65005,'ICC Saurfang 10 Normal'),
+(65006,'ICC Saurfang 10 Heroic'),
+(65007,'ICC Saurfang 25 Normal'),
+(65008,'ICC Saurfang 25 Heroic'),
+(65009,'ICC Mark of Sanctification'),
+(65010,'ICC Heroic Mark of Sanctification');
+
+-- Correct gameobject_template Data1 mapping:
+-- Gunship: 28045=10N, 28072=25N, 28057=10H, 28090=25H.
+-- Saurfang: 28046=10N, 28074=25N, 28058=10H, 28088=25H.
+DELETE FROM `gameobject_loot_template`
+WHERE `entry` IN (28045,28046,28057,28058,28072,28074,28088,28090);
+
+INSERT INTO `gameobject_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+-- Gunship
+(28045,65001,100,0,-65001,2,0,'Two items: Gunship 10 normal'),
+(28045,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28072,65002,100,0,-65002,3,0,'Three items: Gunship 25 normal'),
+(28072,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28072,49908,38,0,1,1,0,'Primordial Saronite'),
+(28072,50274,-35,0,1,1,0,'Shadowfrost Shard quest chance'),
+(28057,65003,100,0,-65003,2,0,'Two items: Gunship 10 heroic'),
+(28057,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28057,49908,38,0,1,1,0,'Primordial Saronite'),
+(28090,65004,100,0,-65004,3,0,'Three items: Gunship 25 heroic'),
+(28090,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28090,49908,50,0,1,1,0,'Primordial Saronite'),
+(28090,50274,-75,0,1,1,0,'Shadowfrost Shard quest chance'),
+-- Saurfang
+(28046,65005,100,0,-65005,2,0,'Two items: Saurfang 10 normal'),
+(28046,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28058,65006,100,0,-65006,2,0,'Two items: Saurfang 10 heroic'),
+(28058,65009,100,0,-65009,1,0,'One normal Sanctification mark'),
+(28058,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28058,49908,20,0,1,1,0,'Primordial Saronite'),
+(28074,65007,100,0,-65007,1,0,'One item: Saurfang 25 normal'),
+(28074,65009,100,0,-65009,2,0,'Two normal Sanctification marks'),
+(28074,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28074,49908,20,0,1,1,0,'Primordial Saronite'),
+(28074,50274,-38,0,1,1,0,'Shadowfrost Shard quest chance'),
+(28088,65008,100,0,-65008,1,0,'One item: Saurfang 25 heroic'),
+(28088,65009,100,0,-65009,2,0,'Two normal Sanctification marks'),
+(28088,65010,100,0,-65010,1,0,'One heroic Sanctification mark'),
+(28088,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(28088,49908,20,0,1,1,0,'Primordial Saronite'),
+(28088,50274,-68,0,1,1,0,'Shadowfrost Shard quest chance');
+
+-- Replace the all-difficulties cache spawns with one object for each mode.
+-- Gunship armories are attached to their transport maps (672 Alliance,
+-- 673 Horde); Saurfang's cache remains on ICC map 631.
+DELETE FROM `gameobject`
+WHERE `map` IN (631,672,673)
+  AND `id` IN (201872,201873,201874,201875,202177,202178,202179,202180,
+               202238,202239,202240,202241);
+
+DELETE FROM `gameobject` WHERE `guid` BETWEEN 6319101 AND 6319112;
+
+INSERT INTO `gameobject`
+(`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`rotation0`,`rotation1`,`rotation2`,`rotation3`,`spawntimesecsmin`,`spawntimesecsmax`) VALUES
+-- Alliance Gunship armory: 10N, 25N, 10H, 25H
+(6319101,201873,672,1,1,-45.4489,-0.062003,20.564,0.26977,0,0,0.134476,0.990917,604800,604800),
+(6319102,201874,672,2,1,-45.4489,-0.062003,20.564,0.26977,0,0,0.134476,0.990917,604800,604800),
+(6319103,201872,672,4,1,-45.4489,-0.062003,20.564,0.26977,0,0,0.134476,0.990917,604800,604800),
+(6319104,201875,672,8,1,-45.4489,-0.062003,20.564,0.26977,0,0,0.134476,0.990917,604800,604800),
+-- Horde Gunship armory: 10N, 25N, 10H, 25H
+(6319105,202178,673,1,1,-19.8726,-14.1748,33.6377,4.71239,0,0,0.707107,-0.707107,604800,604800),
+(6319106,202180,673,2,1,-19.8726,-14.1748,33.6377,4.71239,0,0,0.707107,-0.707107,604800,604800),
+(6319107,202177,673,4,1,-19.8726,-14.1748,33.6377,4.71239,0,0,0.707107,-0.707107,604800,604800),
+(6319108,202179,673,8,1,-19.8726,-14.1748,33.6377,4.71239,0,0,0.707107,-0.707107,604800,604800),
+-- Deathbringer's Cache: 10N, 25N, 10H, 25H
+(6319109,202239,631,1,1,-489.72,2172.07,539.289,2.65289,0,0,0.970295,0.241925,-604800,-604800),
+(6319110,202240,631,2,1,-489.72,2172.07,539.289,2.65289,0,0,0.970295,0.241925,-604800,-604800),
+(6319111,202238,631,4,1,-489.72,2172.07,539.289,2.65289,0,0,0.970295,0.241925,-604800,-604800),
+(6319112,202241,631,8,1,-489.72,2172.07,539.289,2.65289,0,0,0.970295,0.241925,-604800,-604800);
+
+COMMIT;
+
+

--- a/Updates/5868_icc_plagueworks.sql
+++ b/Updates/5868_icc_plagueworks.sql
@@ -1,0 +1,55 @@
+-- Icecrown Citadel Plagueworks encounter and progression data.
+-- Companion update for the Plagueworks ScriptDev2 implementation.
+
+START TRANSACTION;
+
+-- Festergut and Rotface.
+UPDATE `creature_template` SET `ScriptName`='boss_festergut' WHERE `Entry`=36626;
+UPDATE `creature_template` SET `ScriptName`='npc_orange_gas_stalker' WHERE `Entry`=36659;
+UPDATE `creature_template` SET `ScriptName`='boss_rotface' WHERE `Entry`=36627;
+UPDATE `creature_template` SET `ScriptName`='mob_little_ooze' WHERE `Entry`=36897;
+UPDATE `creature_template` SET `ScriptName`='mob_big_ooze' WHERE `Entry`=36899;
+
+-- Professor Putricide and encounter summons.
+UPDATE `creature_template` SET `ScriptName`='boss_professor_putricide' WHERE `Entry`=36678;
+UPDATE `creature_template` SET `ScriptName`='npc_volatile_ooze_icc' WHERE `Entry`=37697;
+UPDATE `creature_template` SET `ScriptName`='npc_gas_cloud_icc' WHERE `Entry`=37562;
+UPDATE `creature_template` SET `ScriptName`='npc_growing_ooze_puddle' WHERE `Entry`=37690;
+UPDATE `creature_template` SET `ScriptName`='npc_choking_gas_bomb' WHERE `Entry`=38159;
+UPDATE `creature_template` SET `ScriptName`='npc_puddle_stalker' WHERE `Entry`=37013;
+
+-- Plagueworks corridor and trap event.
+UPDATE `creature_template` SET `ScriptName`='npc_icc_vengeful_fleshreaper' WHERE `Entry`=37038;
+UPDATE `creature_template` SET `ScriptName`='npc_putricides_trap' WHERE `Entry`=38879;
+
+DELETE FROM `scripted_areatrigger` WHERE `entry`=5647;
+INSERT INTO `scripted_areatrigger` (`entry`,`ScriptName`)
+VALUES (5647,'at_putricides_trap');
+
+DELETE FROM `scripted_event_id` WHERE `id` IN (23426,23438);
+INSERT INTO `scripted_event_id` (`id`,`ScriptName`) VALUES
+(23426,'event_gameobject_citadel_valve'),
+(23438,'event_gameobject_citadel_valve');
+
+-- Spell hooks used by the matching encounter scripts.
+DELETE FROM `spell_scripts` WHERE `Id` IN
+(69165,69290,71222,73033,73034,72219,72551,72552,72553,
+ 69558,69795,70351,72840,70360,69782);
+INSERT INTO `spell_scripts` (`Id`,`ScriptName`) VALUES
+(69165,'spell_inhale_blight'),
+(69290,'spell_festergut_blighted_spores'),
+(71222,'spell_festergut_blighted_spores'),
+(73033,'spell_festergut_blighted_spores'),
+(73034,'spell_festergut_blighted_spores'),
+(72219,'spell_festergut_gastric_bloat'),
+(72551,'spell_festergut_gastric_bloat'),
+(72552,'spell_festergut_gastric_bloat'),
+(72553,'spell_festergut_gastric_bloat'),
+(69558,'spell_unstable_ooze_rotface'),
+(69795,'spell_ooze_flood_trigger'),
+(70351,'spell_unstable_experiment'),
+(72840,'spell_volatile_experiment'),
+(70360,'spell_eat_ooze'),
+(69782,'spell_ooze_flood');
+
+COMMIT;

--- a/Updates/5869_icc_plagueworks_rewards.sql
+++ b/Updates/5869_icc_plagueworks_rewards.sql
@@ -1,0 +1,14 @@
+-- Icecrown Citadel Plagueworks reward correction.
+
+START TRANSACTION;
+
+-- Verified 3.3.5 Professor Putricide coin range for every difficulty row.
+SET @PUTRICIDE_D1 := (SELECT `DifficultyEntry1` FROM `creature_template` WHERE `Entry`=36678);
+SET @PUTRICIDE_D2 := (SELECT `DifficultyEntry2` FROM `creature_template` WHERE `Entry`=36678);
+SET @PUTRICIDE_D3 := (SELECT `DifficultyEntry3` FROM `creature_template` WHERE `Entry`=36678);
+
+UPDATE `creature_template`
+SET `MinLootGold`=400000, `MaxLootGold`=500000
+WHERE `Entry` IN (36678,@PUTRICIDE_D1,@PUTRICIDE_D2,@PUTRICIDE_D3);
+
+COMMIT;

--- a/Updates/5870_icc_crimson_hall.sql
+++ b/Updates/5870_icc_crimson_hall.sql
@@ -1,0 +1,46 @@
+-- Icecrown Citadel Crimson Hall encounter and progression data.
+-- Companion update for the Crimson Hall ScriptDev2 implementation.
+
+START TRANSACTION;
+
+-- Blood Prince Council and encounter actors.
+UPDATE `creature_template` SET `ScriptName`='boss_valanar_icc' WHERE `Entry`=37970;
+UPDATE `creature_template` SET `ScriptName`='boss_keleseth_icc' WHERE `Entry`=37972;
+UPDATE `creature_template` SET `ScriptName`='boss_taldaram_icc' WHERE `Entry`=37973;
+UPDATE `creature_template` SET `ScriptName`='npc_blood_orb_control' WHERE `Entry`=38008;
+UPDATE `creature_template` SET `ScriptName`='npc_dark_nucleus' WHERE `Entry`=38369;
+UPDATE `creature_template` SET `ScriptName`='npc_ball_of_flame' WHERE `Entry` IN (38332,38451);
+UPDATE `creature_template` SET `ScriptName`='npc_kinetic_bomb' WHERE `Entry`=38454;
+
+-- The flame actors provide the spell visual. The separate kinetic helper is
+-- an invisible, non-selectable server actor rather than a visible golem.
+UPDATE `creature_template`
+SET `DisplayId1`=26767,`DisplayId2`=0,`DisplayId3`=0,`DisplayId4`=0,
+    `DisplayIdProbability1`=100,`DisplayIdProbability2`=0,
+    `DisplayIdProbability3`=0,`DisplayIdProbability4`=0
+WHERE `Entry` IN (38332,38451);
+
+UPDATE `creature_template`
+SET `DisplayId1`=21342,`DisplayId2`=0,`DisplayId3`=0,`DisplayId4`=0,
+    `DisplayIdProbability1`=100,`DisplayIdProbability2`=0,
+    `DisplayIdProbability3`=0,`DisplayIdProbability4`=0,
+    `UnitFlags`=`UnitFlags` | 33554432
+WHERE `Entry`=38458;
+
+-- Blood-Queen Lana'thel and her introduction controller.
+UPDATE `creature_template` SET `ScriptName`='npc_queen_lanathel_intro' WHERE `Entry`=38004;
+UPDATE `creature_template` SET `ScriptName`='boss_blood_queen_lanathel' WHERE `Entry`=37955;
+
+-- Spell hooks used by the matching encounter scripts.
+DELETE FROM `spell_scripts` WHERE `Id` IN
+(73001,70946,71475,71476,71477,70877,71474);
+INSERT INTO `spell_scripts` (`Id`,`ScriptName`) VALUES
+(73001,'spell_blood_council_shadow_prison'),
+(70946,'spell_blood_queen_vampiric_bite'),
+(71475,'spell_blood_queen_vampiric_bite'),
+(71476,'spell_blood_queen_vampiric_bite'),
+(71477,'spell_blood_queen_vampiric_bite'),
+(70877,'spell_blood_queen_frenzied_bloodthirst'),
+(71474,'spell_blood_queen_frenzied_bloodthirst');
+
+COMMIT;

--- a/Updates/5871_icc_crimson_hall_rewards.sql
+++ b/Updates/5871_icc_crimson_hall_rewards.sql
@@ -1,0 +1,185 @@
+-- Icecrown Citadel Crimson Hall rewards for 10N, 25N, 10H, and 25H.
+
+START TRANSACTION;
+
+-- Blood Prince Council has one encounter reward owner. Keleseth and Taldaram
+-- must not create additional independent loot or coin rolls.
+SET @KELESETH_D1 := (SELECT `DifficultyEntry1` FROM `creature_template` WHERE `Entry`=37972);
+SET @KELESETH_D2 := (SELECT `DifficultyEntry2` FROM `creature_template` WHERE `Entry`=37972);
+SET @KELESETH_D3 := (SELECT `DifficultyEntry3` FROM `creature_template` WHERE `Entry`=37972);
+SET @TALDARAM_D1 := (SELECT `DifficultyEntry1` FROM `creature_template` WHERE `Entry`=37973);
+SET @TALDARAM_D2 := (SELECT `DifficultyEntry2` FROM `creature_template` WHERE `Entry`=37973);
+SET @TALDARAM_D3 := (SELECT `DifficultyEntry3` FROM `creature_template` WHERE `Entry`=37973);
+
+UPDATE `creature_template`
+SET `LootId`=0,`MinLootGold`=0,`MaxLootGold`=0
+WHERE `Entry` IN
+(37972,@KELESETH_D1,@KELESETH_D2,@KELESETH_D3,
+ 37973,@TALDARAM_D1,@TALDARAM_D2,@TALDARAM_D3);
+
+UPDATE `creature_template` SET `LootId`=`Entry`
+WHERE `Entry` IN (37970,38401,38784,38785);
+
+DELETE FROM `reference_loot_template` WHERE `entry` BETWEEN 65031 AND 65034;
+INSERT INTO `reference_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+(65031,51021,0,1,1,1,0,'Soulbreaker'),
+(65031,51022,0,1,1,1,0,'Hersir''s Greatspear'),
+(65031,51023,0,1,1,1,0,'Taldaram''s Soft Slippers'),
+(65031,51024,0,1,1,1,0,'Thrice Fanged Signet'),
+(65031,51025,0,1,1,1,0,'Battle-Maiden''s Legguards'),
+(65031,51325,0,1,1,1,0,'Blood-Drinker''s Girdle'),
+(65031,51326,0,1,1,1,0,'Wand of Ruby Claret'),
+(65031,51379,0,1,1,1,0,'Bloodsoul Raiment'),
+(65031,51380,0,1,1,1,0,'Pale Corpse Boots'),
+(65031,51381,0,1,1,1,0,'Cerise Coiled Ring'),
+(65031,51382,0,1,1,1,0,'Heartsick Mender''s Cape'),
+(65031,51383,0,1,1,1,0,'Spaulders of the Blood Princes'),
+(65032,49919,0,1,1,1,0,'Cryptmaker'),
+(65032,50071,0,1,1,1,0,'Treads of the Wasteland'),
+(65032,50072,0,1,1,1,0,'Landsoul''s Horned Greathelm'),
+(65032,50073,0,1,1,1,0,'Geistlord''s Punishment Sack'),
+(65032,50074,0,1,1,1,0,'Royal Crimson Cloak'),
+(65032,50075,0,1,1,1,0,'Taldaram''s Plated Fists'),
+(65032,50170,0,1,1,1,0,'Valanar''s Other Signet Ring'),
+(65032,50171,0,1,1,1,0,'Shoulders of Frost-Tipped Thorns'),
+(65032,50172,0,1,1,1,0,'Sanguine Silk Robes'),
+(65032,50173,0,1,1,1,0,'Shadow Silk Spindle'),
+(65032,50174,0,1,1,1,0,'Incarnadine Band of Mending'),
+(65032,50175,0,1,1,1,0,'Crypt Keeper''s Bracers'),
+(65032,50176,0,1,1,1,0,'San''layn Ritualist Gloves'),
+(65032,50177,0,1,1,1,0,'Mail of Crimson Coins'),
+(65032,50184,0,1,1,1,0,'Keleseth''s Seducer'),
+(65033,51847,0,1,1,1,0,'Spaulders of the Blood Princes heroic'),
+(65033,51848,0,1,1,1,0,'Heartsick Mender''s Cape heroic'),
+(65033,51849,0,1,1,1,0,'Cerise Coiled Ring heroic'),
+(65033,51850,0,1,1,1,0,'Pale Corpse Boots heroic'),
+(65033,51851,0,1,1,1,0,'Bloodsoul Raiment heroic'),
+(65033,51852,0,1,1,1,0,'Wand of Ruby Claret heroic'),
+(65033,51853,0,1,1,1,0,'Blood-Drinker''s Girdle heroic'),
+(65033,51854,0,1,1,1,0,'Battle-Maiden''s Legguards heroic'),
+(65033,51855,0,1,1,1,0,'Thrice Fanged Signet heroic'),
+(65033,51856,0,1,1,1,0,'Taldaram''s Soft Slippers heroic'),
+(65033,51857,0,1,1,1,0,'Hersir''s Greatspear heroic'),
+(65033,51858,0,1,1,1,0,'Soulbreaker heroic'),
+(65034,50603,0,1,1,1,0,'Cryptmaker heroic'),
+(65034,50710,0,1,1,1,0,'Keleseth''s Seducer heroic'),
+(65034,50711,0,1,1,1,0,'Treads of the Wasteland heroic'),
+(65034,50712,0,1,1,1,0,'Landsoul''s Horned Greathelm heroic'),
+(65034,50713,0,1,1,1,0,'Geistlord''s Punishment Sack heroic'),
+(65034,50714,0,1,1,1,0,'Valanar''s Other Signet Ring heroic'),
+(65034,50715,0,1,1,1,0,'Shoulders of Frost-Tipped Thorns heroic'),
+(65034,50716,0,1,1,1,0,'Taldaram''s Plated Fists heroic'),
+(65034,50717,0,1,1,1,0,'Sanguine Silk Robes heroic'),
+(65034,50718,0,1,1,1,0,'Royal Crimson Cloak heroic'),
+(65034,50719,0,1,1,1,0,'Shadow Silk Spindle heroic'),
+(65034,50720,0,1,1,1,0,'Incarnadine Band of Mending heroic'),
+(65034,50721,0,1,1,1,0,'Crypt Keeper''s Bracers heroic'),
+(65034,50722,0,1,1,1,0,'San''layn Ritualist Gloves heroic'),
+(65034,50723,0,1,1,1,0,'Mail of Crimson Coins heroic');
+
+REPLACE INTO `reference_loot_template_names` (`entry`,`name`) VALUES
+(65031,'ICC Blood Prince Council 10 Normal'),
+(65032,'ICC Blood Prince Council 25 Normal'),
+(65033,'ICC Blood Prince Council 10 Heroic'),
+(65034,'ICC Blood Prince Council 25 Heroic');
+
+DELETE FROM `creature_loot_template` WHERE `entry` IN (37970,38401,38784,38785);
+INSERT INTO `creature_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+(37970,65031,100,0,-65031,2,0,'Council 10N: two items'),
+(37970,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38401,65032,100,0,-65032,3,0,'Council 25N: three items'),
+(38401,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38401,49908,38,0,1,1,0,'Primordial Saronite'),
+(38401,50274,-38,0,1,1,0,'Shadowfrost Shard quest chance'),
+(38784,65033,100,0,-65033,2,0,'Council 10H: two items'),
+(38784,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38784,49908,38,0,1,1,0,'Primordial Saronite'),
+(38785,65034,100,0,-65034,3,0,'Council 25H: three items'),
+(38785,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38785,49908,38,0,1,1,0,'Primordial Saronite'),
+(38785,50274,-68,0,1,1,0,'Shadowfrost Shard quest chance');
+
+-- Blood-Queen Lana'thel.
+UPDATE `creature_template`
+SET `LootId`=`Entry`,`MinLootGold`=300000,`MaxLootGold`=350000
+WHERE `Entry` IN (37955,38434,38435,38436);
+
+DELETE FROM `reference_loot_template` WHERE `entry` BETWEEN 65101 AND 65106;
+INSERT INTO `reference_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+(65101,51384,0,1,1,1,0,'Bloodsipper'),
+(65101,51385,0,1,1,1,0,'Stakethrower'),
+(65101,51386,0,1,1,1,0,'Throatrender Handguards'),
+(65101,51387,0,1,1,1,0,'Seal of the Twilight Queen'),
+(65101,51548,0,1,1,1,0,'Collar of Haughty Disdain'),
+(65101,51550,0,1,1,1,0,'Ivory-Inlaid Leggings'),
+(65101,51551,0,1,1,1,0,'Chestguard of Siphoned Elements'),
+(65101,51552,0,1,1,1,0,'Shoulderpads of the Searing Kiss'),
+(65101,51553,0,1,1,1,0,'Lana''thel''s Bloody Nail'),
+(65101,51554,0,1,1,1,0,'Cowl of Malefic Repose'),
+(65101,51555,0,1,1,1,0,'Tightening Waistband'),
+(65101,51556,0,1,1,1,0,'Veincrusher Gauntlets'),
+(65102,50065,0,1,1,1,0,'Icecrown Glacial Wall'),
+(65102,50178,0,1,1,1,0,'Bloodfall'),
+(65102,50180,0,1,1,1,0,'Lana''thel''s Chain of Flagellation'),
+(65102,50181,0,1,1,1,0,'Dying Light'),
+(65102,50182,0,1,1,1,0,'Blood Queen''s Crimson Choker'),
+(65102,50354,0,1,1,1,0,'Bauble of True Blood'),
+(65103,51835,0,1,1,1,0,'Veincrusher Gauntlets heroic'),
+(65103,51836,0,1,1,1,0,'Tightening Waistband heroic'),
+(65103,51837,0,1,1,1,0,'Cowl of Malefic Repose heroic'),
+(65103,51838,0,1,1,1,0,'Lana''thel''s Bloody Nail heroic'),
+(65103,51839,0,1,1,1,0,'Shoulderpads of the Searing Kiss heroic'),
+(65103,51840,0,1,1,1,0,'Chestguard of Siphoned Elements heroic'),
+(65103,51841,0,1,1,1,0,'Ivory-Inlaid Leggings heroic'),
+(65103,51842,0,1,1,1,0,'Collar of Haughty Disdain heroic'),
+(65103,51843,0,1,1,1,0,'Seal of the Twilight Queen heroic'),
+(65103,51844,0,1,1,1,0,'Throatrender Handguards heroic'),
+(65103,51845,0,1,1,1,0,'Stakethrower heroic'),
+(65103,51846,0,1,1,1,0,'Bloodsipper heroic'),
+(65104,50724,0,1,1,1,0,'Blood Queen''s Crimson Choker heroic'),
+(65104,50725,0,1,1,1,0,'Dying Light heroic'),
+(65104,50726,0,1,1,1,0,'Bauble of True Blood heroic'),
+(65104,50727,0,1,1,1,0,'Bloodfall heroic'),
+(65104,50728,0,1,1,1,0,'Lana''thel''s Chain of Flagellation heroic'),
+(65104,50729,0,1,1,1,0,'Icecrown Glacial Wall heroic'),
+(65105,52025,0,1,1,1,0,'Vanquisher''s Mark of Sanctification'),
+(65105,52026,0,1,1,1,0,'Protector''s Mark of Sanctification'),
+(65105,52027,0,1,1,1,0,'Conqueror''s Mark of Sanctification'),
+(65106,52028,0,1,1,1,0,'Vanquisher''s Mark of Sanctification heroic'),
+(65106,52029,0,1,1,1,0,'Protector''s Mark of Sanctification heroic'),
+(65106,52030,0,1,1,1,0,'Conqueror''s Mark of Sanctification heroic');
+
+DELETE FROM `reference_loot_template_names` WHERE `entry` BETWEEN 65101 AND 65106;
+INSERT INTO `reference_loot_template_names` (`entry`,`name`) VALUES
+(65101,'ICC Blood-Queen Lana''thel 10 Normal'),
+(65102,'ICC Blood-Queen Lana''thel 25 Normal'),
+(65103,'ICC Blood-Queen Lana''thel 10 Heroic'),
+(65104,'ICC Blood-Queen Lana''thel 25 Heroic'),
+(65105,'ICC Blood-Queen normal Marks'),
+(65106,'ICC Blood-Queen heroic Marks');
+
+DELETE FROM `creature_loot_template` WHERE `entry` IN (37955,38434,38435,38436);
+INSERT INTO `creature_loot_template`
+(`entry`,`item`,`ChanceOrQuestChance`,`groupid`,`mincountOrRef`,`maxcount`,`condition_id`,`comments`) VALUES
+(37955,65101,100,0,-65101,2,0,'Blood Queen 10N: two items'),
+(37955,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38434,65102,100,0,-65102,1,0,'Blood Queen 25N: one weapon or trinket'),
+(38434,65105,100,0,-65105,2,0,'Blood Queen 25N: two normal marks'),
+(38434,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38434,49908,38,0,1,1,0,'Primordial Saronite'),
+(38434,50274,-38,0,1,1,0,'Shadowfrost Shard quest chance'),
+(38435,65103,100,0,-65103,2,0,'Blood Queen 10H: two heroic items'),
+(38435,65105,100,0,-65105,1,0,'Blood Queen 10H: one normal mark'),
+(38435,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38435,49908,38,0,1,1,0,'Primordial Saronite'),
+(38436,65104,100,0,-65104,1,0,'Blood Queen 25H: one heroic weapon or trinket'),
+(38436,65105,100,0,-65105,2,0,'Blood Queen 25H: two normal marks'),
+(38436,65106,100,0,-65106,1,0,'Blood Queen 25H: one heroic mark'),
+(38436,49426,100,0,2,2,0,'Emblem of Frost x2'),
+(38436,49908,38,0,1,1,0,'Primordial Saronite'),
+(38436,50274,-68,0,1,1,0,'Shadowfrost Shard quest chance');
+
+COMMIT;


### PR DESCRIPTION
## Summary

Database companion for the Crimson Hall core restoration.

- assigns the Blood Prince Council and Blood-Queen Lana'thel scripts and spell hooks
- corrects helper visuals used by Kinetic Bomb and Ball of Flame mechanics
- assigns Council loot to the proper reward owner instead of all three princes
- restores Council and Blood-Queen rewards for 10/25-player normal and heroic modes
- uses the existing CMaNGOS world schema; no new tables or schema changes are introduced

The SQL has been reviewed against the current WotLK database layout. Runtime verification of the exact core/database PR pair is still in progress.

This is stacked on the Lower Spire database restoration in #1379 and the Plagueworks database restoration in #1381. Core companion: cmangos/mangos-wotlk#670.
